### PR TITLE
Update exported API for simplificaiton 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@ Compression is provided from the [github.com/klauspost/compress](https://github.
 
 # Usage
 
-The `compress.All` function will return options that allow both client and servers to compress and decompress all
+The `compress.WithAll` function will return an option that allows both client and servers to compress and decompress all
 formats.
 
 ```
-    // Get client and server options for all compressors...
-    clientOpts, serverOpts := compress.All(compress.LevelBalanced)
+    // Get the client and server option for all compressors...
+    opts := compress.WithAll(compress.LevelBalanced)
+
+    // enable on server
+    _, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opts)
+
+    // enable on client
+    client := pingv1connect.NewPingServiceClient(http.DefaultClient, url, opts)
+
 ```
 
 By default the order of preference by the clients is S2, Snappy, Zstandard, Gzip.

--- a/compress.go
+++ b/compress.go
@@ -106,23 +106,17 @@ type compressorOption struct {
 // WithAll returns the client and handler option for all compression methods.
 // Order of preference is S2, Snappy, Zstandard, Gzip.
 func WithAll(level Level, options ...Opts) connect.Option {
-	var hopts []connect.HandlerOption
-	var copts []connect.ClientOption
+	var opts []connect.Option
 
 	for _, name := range []string{Gzip, Zstandard, Snappy, S2} {
-		c, h := Select(name, level, options...)
-		copts = append(copts, c)
-		hopts = append(hopts, h)
+		opts = append(opts, Select(name, level, options...))
 	}
-	return &compressorOption{
-		ClientOption:  connect.WithClientOptions(copts...),
-		HandlerOption: connect.WithHandlerOptions(hopts...),
-	}
+	return connect.WithOptions(opts...)
 }
 
 // Select returns client and handler options for a single compression method.
 // Name must be one of the predefined in this package.
-func Select(name string, level Level, options ...Opts) (connect.ClientOption, connect.HandlerOption) {
+func Select(name string, level Level, options ...Opts) connect.Option {
 	var o Opts
 	for _, opt := range options {
 		o = o | opt
@@ -142,7 +136,10 @@ func Select(name string, level Level, options ...Opts) (connect.ClientOption, co
 	default:
 		panic(fmt.Errorf("unknown compression name: %s", name))
 	}
-	return connect.WithAcceptCompression(name, d, c), connect.WithCompression(name, d, c)
+	return &compressorOption{
+		ClientOption:  connect.WithAcceptCompression(name, d, c),
+		HandlerOption: connect.WithCompression(name, d, c),
+	}
 }
 
 func gzComp(level Level, o Opts) (d func() connect.Decompressor, c func() connect.Compressor) {

--- a/compress.go
+++ b/compress.go
@@ -103,9 +103,9 @@ type compressorOption struct {
 	connect.HandlerOption
 }
 
-// All returns the client and handler option for all compression methods.
+// WithAll returns the client and handler option for all compression methods.
 // Order of preference is S2, Snappy, Zstandard, Gzip.
-func All(level Level, options ...Opts) connect.Option {
+func WithAll(level Level, options ...Opts) connect.Option {
 	var hopts []connect.HandlerOption
 	var copts []connect.ClientOption
 

--- a/compress.go
+++ b/compress.go
@@ -109,14 +109,14 @@ func WithAll(level Level, options ...Opts) connect.Option {
 	var opts []connect.Option
 
 	for _, name := range []string{Gzip, Zstandard, Snappy, S2} {
-		opts = append(opts, Select(name, level, options...))
+		opts = append(opts, WithNew(name, level, options...))
 	}
 	return connect.WithOptions(opts...)
 }
 
-// Select returns client and handler options for a single compression method.
+// WithNew returns client and handler options for a single compression method.
 // Name must be one of the predefined in this package.
-func Select(name string, level Level, options ...Opts) connect.Option {
+func WithNew(name string, level Level, options ...Opts) connect.Option {
 	var o Opts
 	for _, opt := range options {
 		o = o | opt

--- a/compress.go
+++ b/compress.go
@@ -98,9 +98,14 @@ const (
 	optSnappy
 )
 
-// All returns client and handler options for all compression methods.
+type compressorOption struct {
+	connect.ClientOption
+	connect.HandlerOption
+}
+
+// All returns the client and handler option for all compression methods.
 // Order of preference is S2, Snappy, Zstandard, Gzip.
-func All(level Level, options ...Opts) (connect.ClientOption, connect.HandlerOption) {
+func All(level Level, options ...Opts) connect.Option {
 	var hopts []connect.HandlerOption
 	var copts []connect.ClientOption
 
@@ -109,8 +114,10 @@ func All(level Level, options ...Opts) (connect.ClientOption, connect.HandlerOpt
 		copts = append(copts, c)
 		hopts = append(hopts, h)
 	}
-
-	return connect.WithClientOptions(copts...), connect.WithHandlerOptions(hopts...)
+	return &compressorOption{
+		ClientOption:  connect.WithClientOptions(copts...),
+		HandlerOption: connect.WithHandlerOptions(hopts...),
+	}
 }
 
 // Select returns client and handler options for a single compression method.

--- a/example_test.go
+++ b/example_test.go
@@ -59,7 +59,7 @@ func ExampleWithAll() {
 
 func ExampleSelect() {
 	// Add Zstandard.
-	opt := compress.Select(compress.Zstandard, compress.LevelBalanced)
+	opt := compress.WithNew(compress.Zstandard, compress.LevelBalanced)
 	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opt)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
@@ -87,7 +87,7 @@ func ExampleSelect() {
 
 func ExampleSelect2() {
 	// Add Zstandard.
-	opt := compress.Select(compress.Snappy, compress.LevelBalanced)
+	opt := compress.WithNew(compress.Snappy, compress.LevelBalanced)
 	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opt)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
@@ -115,7 +115,7 @@ func ExampleSelect2() {
 
 func ExampleSelect3() {
 	// Add Zstandard.
-	opt := compress.Select(compress.S2, compress.LevelBalanced)
+	opt := compress.WithNew(compress.S2, compress.LevelBalanced)
 	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opt)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
@@ -143,7 +143,7 @@ func ExampleSelect3() {
 
 func ExampleSelect4() {
 	// Add Zstandard.
-	opt := compress.Select(compress.Gzip, compress.LevelBalanced)
+	opt := compress.WithNew(compress.Gzip, compress.LevelBalanced)
 	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opt)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(

--- a/example_test.go
+++ b/example_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/klauspost/connect-compress/internal/gen/connect/ping/v1/pingv1connect"
 )
 
-func ExampleAll() {
-	// Get client and server options for all compressors...
+func ExampleWithAll() {
+	// Get the client and server option for all compressors...
 	opts := compress.WithAll(compress.LevelBalanced)
 
 	// Create a server.

--- a/example_test.go
+++ b/example_test.go
@@ -29,7 +29,7 @@ import (
 
 func ExampleAll() {
 	// Get client and server options for all compressors...
-	opts := compress.All(compress.LevelBalanced)
+	opts := compress.WithAll(compress.LevelBalanced)
 
 	// Create a server.
 	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opts)

--- a/example_test.go
+++ b/example_test.go
@@ -29,15 +29,15 @@ import (
 
 func ExampleAll() {
 	// Get client and server options for all compressors...
-	clientOpts, serverOpts := compress.All(compress.LevelBalanced)
+	opts := compress.All(compress.LevelBalanced)
 
 	// Create a server.
-	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, serverOpts)
+	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opts)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
 		http.DefaultClient,
 		srv.URL,
-		clientOpts,
+		opts,
 		// Compress requests with S2.
 		connect.WithSendCompression(compress.S2),
 	)

--- a/example_test.go
+++ b/example_test.go
@@ -59,13 +59,13 @@ func ExampleWithAll() {
 
 func ExampleSelect() {
 	// Add Zstandard.
-	clientOpts, serverOpts := compress.Select(compress.Zstandard, compress.LevelBalanced)
-	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, serverOpts)
+	opt := compress.Select(compress.Zstandard, compress.LevelBalanced)
+	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opt)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
 		http.DefaultClient,
 		srv.URL,
-		clientOpts,
+		opt,
 		// Enable request compression
 		connect.WithSendCompression(compress.Zstandard),
 	)
@@ -87,13 +87,13 @@ func ExampleSelect() {
 
 func ExampleSelect2() {
 	// Add Zstandard.
-	clientOpts, serverOpts := compress.Select(compress.Snappy, compress.LevelBalanced)
-	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, serverOpts)
+	opt := compress.Select(compress.Snappy, compress.LevelBalanced)
+	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opt)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
 		http.DefaultClient,
 		srv.URL,
-		clientOpts,
+		opt,
 		// Enable request compression
 		connect.WithSendCompression(compress.Snappy),
 	)
@@ -115,13 +115,13 @@ func ExampleSelect2() {
 
 func ExampleSelect3() {
 	// Add Zstandard.
-	clientOpts, serverOpts := compress.Select(compress.S2, compress.LevelBalanced)
-	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, serverOpts)
+	opt := compress.Select(compress.S2, compress.LevelBalanced)
+	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opt)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
 		http.DefaultClient,
 		srv.URL,
-		clientOpts,
+		opt,
 		// Enable request compression
 		connect.WithSendCompression(compress.S2),
 	)
@@ -143,13 +143,13 @@ func ExampleSelect3() {
 
 func ExampleSelect4() {
 	// Add Zstandard.
-	clientOpts, serverOpts := compress.Select(compress.Gzip, compress.LevelBalanced)
-	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, serverOpts)
+	opt := compress.Select(compress.Gzip, compress.LevelBalanced)
+	_, h := pingv1connect.NewPingServiceHandler(&pingServer{}, opt)
 	srv := httptest.NewServer(h)
 	client := pingv1connect.NewPingServiceClient(
 		http.DefaultClient,
 		srv.URL,
-		clientOpts,
+		opt,
 		// Enable request compression
 		connect.WithSendCompression(compress.Gzip),
 	)


### PR DESCRIPTION
Hey! 
Just opened up this pr with some changed that I think will bring the api a little closer to what connect-go uses.

Changes two things:
- All is renamed to `WithAll` to come closer to terminology used in connect-go around option naming
- WithAll returns a single `connect.Option` that can be passed into handler or client constructors.

Let me know what you think