### PR TITLE
connect-go is now at connectrpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GoDoc](https://pkg.go.dev/badge/github.com/klauspost/connect-compress.svg)](https://pkg.go.dev/github.com/klauspost/connect-compress)
 
-This package provides improved compression schemes for [Buf Connect](https://github.com/bufbuild/connect-go).
+This package provides improved compression schemes for [Connect](https://github.com/connectrpc/connect-go).
 
 Compression is provided from the [github.com/klauspost/compress](https://github.com/klauspost/compress) package.
 

--- a/compress.go
+++ b/compress.go
@@ -17,9 +17,8 @@ package compress
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 
-	"github.com/bufbuild/connect-go"
+	"connectrpc.com/connect"
 	"github.com/klauspost/compress/gzip"
 	"github.com/klauspost/compress/s2"
 	"github.com/klauspost/compress/zstd"
@@ -147,18 +146,21 @@ func gzComp(level Level, o Opts) (d func() connect.Decompressor, c func() connec
 			return &gzip.Reader{}
 		}, func() connect.Compressor {
 			if o.contains(OptStatelessGzip) {
-				gz, _ := gzip.NewWriterLevel(ioutil.Discard, gzip.StatelessCompression)
+				gz, _ := gzip.NewWriterLevel(io.Discard, gzip.StatelessCompression)
 				return gz
 			}
 			switch level {
 			case LevelFastest:
-				gz, _ := gzip.NewWriterLevel(ioutil.Discard, 1)
+				gz, _ := gzip.NewWriterLevel(io.Discard, 1)
+				return gz
+			case LevelBalanced:
+				gz, _ := gzip.NewWriterLevel(io.Discard, 5)
 				return gz
 			case LevelSmallest:
-				gz, _ := gzip.NewWriterLevel(ioutil.Discard, 9)
+				gz, _ := gzip.NewWriterLevel(io.Discard, 9)
 				return gz
 			}
-			return gzip.NewWriter(ioutil.Discard)
+			return gzip.NewWriter(io.Discard)
 		}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 
-	"github.com/bufbuild/connect-go"
+	"connectrpc.com/connect"
 	compress "github.com/klauspost/connect-compress"
 	pingv1 "github.com/klauspost/connect-compress/internal/gen/connect/ping/v1"
 	"github.com/klauspost/connect-compress/internal/gen/connect/ping/v1/pingv1connect"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/klauspost/connect-compress
 go 1.18
 
 require (
-	github.com/bufbuild/connect-go v1.1.0
-	github.com/klauspost/compress v1.15.12
-	google.golang.org/protobuf v1.28.1
+	connectrpc.com/connect v1.11.0
+	github.com/klauspost/compress v1.16.7
+	google.golang.org/protobuf v1.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,13 @@
-github.com/bufbuild/connect-go v1.1.0 h1:AUgqqO2ePdOJSpPOep6BPYz5v2moW1Lb8sQh0EeRzQ8=
-github.com/bufbuild/connect-go v1.1.0/go.mod h1:9iNvh/NOsfhNBUH5CtvXeVUskQO1xsrEviH7ZArwZ3I=
+connectrpc.com/connect v1.11.0 h1:Av2KQXxSaX4vjqhf5Cl01SX4dqYADQ38eBtr84JSUBk=
+connectrpc.com/connect v1.11.0/go.mod h1:3AGaO6RRGMx5IKFfqbe3hvK1NqLosFNP2BxDYTPmNPo=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/klauspost/compress v1.15.12 h1:YClS/PImqYbn+UILDnqxQCZ3RehC9N318SU3kElDUEM=
 github.com/klauspost/compress v1.15.12/go.mod h1:QPwzmACJjUTFsnSHH934V6woptycfrDDJnH7hvFVbGM=
+github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
+github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
+++ b/internal/gen/connect/ping/v1/pingv1connect/ping.connect.go
@@ -24,7 +24,7 @@ import (
 	"net/http"
 	"strings"
 
-	connect_go "github.com/bufbuild/connect-go"
+	"connectrpc.com/connect"
 	v1 "github.com/klauspost/connect-compress/internal/gen/connect/ping/v1"
 )
 
@@ -33,7 +33,7 @@ import (
 // generated with a version of connect newer than the one compiled into your binary. You can fix the
 // problem by either regenerating this code with an older version of connect or updating the connect
 // version compiled into your binary.
-const _ = connect_go.IsAtLeastVersion0_1_0
+const _ = connect.IsAtLeastVersion0_1_0
 
 const (
 	// PingServiceName is the fully-qualified name of the PingService service.
@@ -43,15 +43,15 @@ const (
 // PingServiceClient is a client for the connect.ping.v1.PingService service.
 type PingServiceClient interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error)
+	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
 	// Fail always fails.
-	Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error)
+	Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context) *connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
+	Sum(context.Context) *connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse]
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest]) (*connect_go.ServerStreamForClient[v1.CountUpResponse], error)
+	CountUp(context.Context, *connect.Request[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error)
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
-	CumSum(context.Context) *connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
+	CumSum(context.Context) *connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse]
 }
 
 // NewPingServiceClient constructs a client for the connect.ping.v1.PingService service. By default,
@@ -61,30 +61,30 @@ type PingServiceClient interface {
 //
 // The URL supplied here should be the base URL for the Connect or gRPC server (for example,
 // http://api.acme.com or https://acme.com/grpc).
-func NewPingServiceClient(httpClient connect_go.HTTPClient, baseURL string, opts ...connect_go.ClientOption) PingServiceClient {
+func NewPingServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) PingServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
 	return &pingServiceClient{
-		ping: connect_go.NewClient[v1.PingRequest, v1.PingResponse](
+		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
 			httpClient,
 			baseURL+"/connect.ping.v1.PingService/Ping",
 			opts...,
 		),
-		fail: connect_go.NewClient[v1.FailRequest, v1.FailResponse](
+		fail: connect.NewClient[v1.FailRequest, v1.FailResponse](
 			httpClient,
 			baseURL+"/connect.ping.v1.PingService/Fail",
 			opts...,
 		),
-		sum: connect_go.NewClient[v1.SumRequest, v1.SumResponse](
+		sum: connect.NewClient[v1.SumRequest, v1.SumResponse](
 			httpClient,
 			baseURL+"/connect.ping.v1.PingService/Sum",
 			opts...,
 		),
-		countUp: connect_go.NewClient[v1.CountUpRequest, v1.CountUpResponse](
+		countUp: connect.NewClient[v1.CountUpRequest, v1.CountUpResponse](
 			httpClient,
 			baseURL+"/connect.ping.v1.PingService/CountUp",
 			opts...,
 		),
-		cumSum: connect_go.NewClient[v1.CumSumRequest, v1.CumSumResponse](
+		cumSum: connect.NewClient[v1.CumSumRequest, v1.CumSumResponse](
 			httpClient,
 			baseURL+"/connect.ping.v1.PingService/CumSum",
 			opts...,
@@ -94,50 +94,50 @@ func NewPingServiceClient(httpClient connect_go.HTTPClient, baseURL string, opts
 
 // pingServiceClient implements PingServiceClient.
 type pingServiceClient struct {
-	ping    *connect_go.Client[v1.PingRequest, v1.PingResponse]
-	fail    *connect_go.Client[v1.FailRequest, v1.FailResponse]
-	sum     *connect_go.Client[v1.SumRequest, v1.SumResponse]
-	countUp *connect_go.Client[v1.CountUpRequest, v1.CountUpResponse]
-	cumSum  *connect_go.Client[v1.CumSumRequest, v1.CumSumResponse]
+	ping    *connect.Client[v1.PingRequest, v1.PingResponse]
+	fail    *connect.Client[v1.FailRequest, v1.FailResponse]
+	sum     *connect.Client[v1.SumRequest, v1.SumResponse]
+	countUp *connect.Client[v1.CountUpRequest, v1.CountUpResponse]
+	cumSum  *connect.Client[v1.CumSumRequest, v1.CumSumResponse]
 }
 
 // Ping calls connect.ping.v1.PingService.Ping.
-func (c *pingServiceClient) Ping(ctx context.Context, req *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error) {
+func (c *pingServiceClient) Ping(ctx context.Context, req *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
 	return c.ping.CallUnary(ctx, req)
 }
 
 // Fail calls connect.ping.v1.PingService.Fail.
-func (c *pingServiceClient) Fail(ctx context.Context, req *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error) {
+func (c *pingServiceClient) Fail(ctx context.Context, req *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
 	return c.fail.CallUnary(ctx, req)
 }
 
 // Sum calls connect.ping.v1.PingService.Sum.
-func (c *pingServiceClient) Sum(ctx context.Context) *connect_go.ClientStreamForClient[v1.SumRequest, v1.SumResponse] {
+func (c *pingServiceClient) Sum(ctx context.Context) *connect.ClientStreamForClient[v1.SumRequest, v1.SumResponse] {
 	return c.sum.CallClientStream(ctx)
 }
 
 // CountUp calls connect.ping.v1.PingService.CountUp.
-func (c *pingServiceClient) CountUp(ctx context.Context, req *connect_go.Request[v1.CountUpRequest]) (*connect_go.ServerStreamForClient[v1.CountUpResponse], error) {
+func (c *pingServiceClient) CountUp(ctx context.Context, req *connect.Request[v1.CountUpRequest]) (*connect.ServerStreamForClient[v1.CountUpResponse], error) {
 	return c.countUp.CallServerStream(ctx, req)
 }
 
 // CumSum calls connect.ping.v1.PingService.CumSum.
-func (c *pingServiceClient) CumSum(ctx context.Context) *connect_go.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse] {
+func (c *pingServiceClient) CumSum(ctx context.Context) *connect.BidiStreamForClient[v1.CumSumRequest, v1.CumSumResponse] {
 	return c.cumSum.CallBidiStream(ctx)
 }
 
 // PingServiceHandler is an implementation of the connect.ping.v1.PingService service.
 type PingServiceHandler interface {
 	// Ping sends a ping to the server to determine if it's reachable.
-	Ping(context.Context, *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error)
+	Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error)
 	// Fail always fails.
-	Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error)
+	Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error)
 	// Sum calculates the sum of the numbers sent on the stream.
-	Sum(context.Context, *connect_go.ClientStream[v1.SumRequest]) (*connect_go.Response[v1.SumResponse], error)
+	Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error)
 	// CountUp returns a stream of the numbers up to the given request.
-	CountUp(context.Context, *connect_go.Request[v1.CountUpRequest], *connect_go.ServerStream[v1.CountUpResponse]) error
+	CountUp(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error
 	// CumSum determines the cumulative sum of all the numbers sent on the stream.
-	CumSum(context.Context, *connect_go.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error
+	CumSum(context.Context, *connect.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error
 }
 
 // NewPingServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -145,29 +145,29 @@ type PingServiceHandler interface {
 //
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
-func NewPingServiceHandler(svc PingServiceHandler, opts ...connect_go.HandlerOption) (string, http.Handler) {
+func NewPingServiceHandler(svc PingServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	mux := http.NewServeMux()
-	mux.Handle("/connect.ping.v1.PingService/Ping", connect_go.NewUnaryHandler(
+	mux.Handle("/connect.ping.v1.PingService/Ping", connect.NewUnaryHandler(
 		"/connect.ping.v1.PingService/Ping",
 		svc.Ping,
 		opts...,
 	))
-	mux.Handle("/connect.ping.v1.PingService/Fail", connect_go.NewUnaryHandler(
+	mux.Handle("/connect.ping.v1.PingService/Fail", connect.NewUnaryHandler(
 		"/connect.ping.v1.PingService/Fail",
 		svc.Fail,
 		opts...,
 	))
-	mux.Handle("/connect.ping.v1.PingService/Sum", connect_go.NewClientStreamHandler(
+	mux.Handle("/connect.ping.v1.PingService/Sum", connect.NewClientStreamHandler(
 		"/connect.ping.v1.PingService/Sum",
 		svc.Sum,
 		opts...,
 	))
-	mux.Handle("/connect.ping.v1.PingService/CountUp", connect_go.NewServerStreamHandler(
+	mux.Handle("/connect.ping.v1.PingService/CountUp", connect.NewServerStreamHandler(
 		"/connect.ping.v1.PingService/CountUp",
 		svc.CountUp,
 		opts...,
 	))
-	mux.Handle("/connect.ping.v1.PingService/CumSum", connect_go.NewBidiStreamHandler(
+	mux.Handle("/connect.ping.v1.PingService/CumSum", connect.NewBidiStreamHandler(
 		"/connect.ping.v1.PingService/CumSum",
 		svc.CumSum,
 		opts...,
@@ -178,22 +178,22 @@ func NewPingServiceHandler(svc PingServiceHandler, opts ...connect_go.HandlerOpt
 // UnimplementedPingServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedPingServiceHandler struct{}
 
-func (UnimplementedPingServiceHandler) Ping(context.Context, *connect_go.Request[v1.PingRequest]) (*connect_go.Response[v1.PingResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Ping is not implemented"))
+func (UnimplementedPingServiceHandler) Ping(context.Context, *connect.Request[v1.PingRequest]) (*connect.Response[v1.PingResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Ping is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Fail(context.Context, *connect_go.Request[v1.FailRequest]) (*connect_go.Response[v1.FailResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail is not implemented"))
+func (UnimplementedPingServiceHandler) Fail(context.Context, *connect.Request[v1.FailRequest]) (*connect.Response[v1.FailResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Fail is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) Sum(context.Context, *connect_go.ClientStream[v1.SumRequest]) (*connect_go.Response[v1.SumResponse], error) {
-	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
+func (UnimplementedPingServiceHandler) Sum(context.Context, *connect.ClientStream[v1.SumRequest]) (*connect.Response[v1.SumResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.Sum is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect_go.Request[v1.CountUpRequest], *connect_go.ServerStream[v1.CountUpResponse]) error {
-	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CountUp is not implemented"))
+func (UnimplementedPingServiceHandler) CountUp(context.Context, *connect.Request[v1.CountUpRequest], *connect.ServerStream[v1.CountUpResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CountUp is not implemented"))
 }
 
-func (UnimplementedPingServiceHandler) CumSum(context.Context, *connect_go.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error {
-	return connect_go.NewError(connect_go.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CumSum is not implemented"))
+func (UnimplementedPingServiceHandler) CumSum(context.Context, *connect.BidiStream[v1.CumSumRequest, v1.CumSumResponse]) error {
+	return connect.NewError(connect.CodeUnimplemented, errors.New("connect.ping.v1.PingService.CumSum is not implemented"))
 }


### PR DESCRIPTION
This change is required to be able to use this library if the consumer was already migrated to connectrpc